### PR TITLE
Make all variant themes point to the original

### DIFF
--- a/files.json
+++ b/files.json
@@ -199,7 +199,7 @@
 			"updated":"2015-07-01",
 			"discussion":"http://perfectworld.vanillaforums.com/discussion/7895#latest",
 			"category":"Theme",
-			"variant":"Pro Red"
+			"variant":"Pro Blue"
 		},
 		
 		"Pro Red":
@@ -303,7 +303,7 @@
 			"updated":"2015-07-01",
 			"discussion":"http://perfectworld.vanillaforums.com/discussion/7895#latest",
 			"category":"Theme",
-			"variant":"STO KDF"
+			"variant":"STO Federation"
 		},
 		
 		"STO KDF":
@@ -329,7 +329,7 @@
 			"updated":"2015-07-01",
 			"discussion":"http://perfectworld.vanillaforums.com/discussion/7895#latest",
 			"category":"Theme",
-			"variant":"STO Romulan"
+			"variant":"STO Federation"
 		},
 		
 		"STO Romulan":


### PR DESCRIPTION
It's easier to identify the original if they all point to it.  I'll be storing information about the currently selected variant in this node locally.
